### PR TITLE
Prevent XSS injection

### DIFF
--- a/sendtesterror.php
+++ b/sendtesterror.php
@@ -47,7 +47,7 @@ if ($_GET['rg4wp_status'] && function_exists('curl_version') && $_GET['rg4wp_api
 	$previousUrl = "javascript:window.history.back();";
 
 	if( isset($_GET['backurl']) ) {
-		$previousUrl = $_GET["backurl"];
+		$previousUrl = htmlentities($_GET["backurl"]);
 	}
 ?>
 


### PR DESCRIPTION
Add `htmlentities` check around $_GET request preventing XSS injection when sending test errors.