### PR TITLE
Remove global keyword from main script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+# JetBrains
+.idea


### PR DESCRIPTION
### Overview

The global keyword is no longer supported in PHP7. This has been replaced with getter functions which use the `static` keyword to cache the client and tags.

### Updates

- Require the client script only once at the top of the main script
- Add getter functions which replace the `global $client` and `global $tags` calls
- The `rg4wp_checkUser` function no longer changes the client as we can access the getter function inside this function