### PR TITLE
Replace references to 'User tracking' with 'Customers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This feature automatically tracks JavaScript errors that occur in your user's br
 
 This setting can be activated via the Settings page.
 
-## Unique user tracking
+## Customer Experience Monitoring
 
 This feature can be enabled via the Settings page.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ As of 1.8 of Raygun4WP plugin you can enable [real user monitoring](https://rayg
 
 This feature can be enabled via the Settings page under **Pulse - Real User Monitoring**.
 
-User information will be sent along if you have the unique user tracking feature enabled.
+User information will be sent along if you have the 'Customers' feature enabled.
 
 ## Client-side error tracking
 
@@ -52,7 +52,7 @@ This feature automatically tracks JavaScript errors that occur in your user's br
 
 This setting can be activated via the Settings page.
 
-## Customer Experience Monitoring
+## Customers
 
 This feature can be enabled via the Settings page.
 

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ Done!
 
 As of 1.8, you can enable [real user monitoring](https://raygun.com/products/real-user-monitoring) by navigating to the Raygun4WP settings page and checking the **Enable Real User Monitoring** checkbox.
 
-User information will be sent along if you have the Customer Experience Monitoring feature enabled.
+User information will be sent along if you have the Customers feature enabled.
 
 = Client-side JavaScript error tracking =
 
@@ -74,14 +74,14 @@ It is recommended to use the most recent version WordPress and PHP possible. Thi
 
 Finally, if you so desire you should be able to visit the root network site, activate it there and configure it. You must however activate it on at least one child site first.
 
-= How do I use Customer Experience Monitoring? =
+= How do I use Customers? =
 
 If you enable this feature the currently logged in user's email address, first name and last name will be transmitted along with each message. This will be visible in the Raygun dashboard. If they have associated a Gravatar with that address, you will see their picture. If this feature is not enabled, a random ID will be assigned to each user. Either way, you can view a count of the affected users for each error.
 
 == Changelog  ==
 
 = 1.9.1 =
-* Don't set user cookie when Customer Experience Monitoring is disabled
+* Don't set user cookie when Customers is disabled
 
 = 1.9.0 =
 
@@ -107,7 +107,7 @@ If you enable this feature the currently logged in user's email address, first n
 * Bump Raygun4JS dependency to v2.4.0
 * Bump Raygun4PHP dependency to v1.7.0
 * Pulse support added
-* Raygun4JS also includes Customer Experience Monitoring
+* Raygun4JS also includes 'Customers'
 * Restructured the settings screen
 * JavaScript error tagging option added
 * Fixed an issue where the Send Test Error page wouldn't display results
@@ -115,7 +115,7 @@ If you enable this feature the currently logged in user's email address, first n
 * Raygun Dashboard uses more space to provide a better user experience
 * Updated notifications
 * Raygun4JS tracks the version Wordpress being used
-* Customer Experience Monitoring also tracks the users first & last names
+* Customers also tracks the users first & last names
 
 = 1.7.3 =
 
@@ -174,7 +174,7 @@ If you enable this feature the currently logged in user's email address, first n
 
 = 1.1.0.0 =
 
-* Added Customer Experience Monitoring support to Settings page
+* Added 'Customers' support to Settings page
 * Updated internal Raygun4PHP to use latest v1.1
 
 = 1.0.3.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ Done!
 
 As of 1.8, you can enable [real user monitoring](https://raygun.com/products/real-user-monitoring) by navigating to the Raygun4WP settings page and checking the **Enable Real User Monitoring** checkbox.
 
-User information will be sent along if you have the unique user tracking feature enabled.
+User information will be sent along if you have the Customer Experience Monitoring feature enabled.
 
 = Client-side JavaScript error tracking =
 
@@ -74,14 +74,14 @@ It is recommended to use the most recent version WordPress and PHP possible. Thi
 
 Finally, if you so desire you should be able to visit the root network site, activate it there and configure it. You must however activate it on at least one child site first.
 
-= How do I use the unique user tracking feature? =
+= How do I use Customer Experience Monitoring? =
 
 If you enable this feature the currently logged in user's email address, first name and last name will be transmitted along with each message. This will be visible in the Raygun dashboard. If they have associated a Gravatar with that address, you will see their picture. If this feature is not enabled, a random ID will be assigned to each user. Either way, you can view a count of the affected users for each error.
 
 == Changelog  ==
 
 = 1.9.1 =
-* Don't set user cookie when user tracking is disabled
+* Don't set user cookie when Customer Experience Monitoring is disabled
 
 = 1.9.0 =
 
@@ -107,7 +107,7 @@ If you enable this feature the currently logged in user's email address, first n
 * Bump Raygun4JS dependency to v2.4.0
 * Bump Raygun4PHP dependency to v1.7.0
 * Pulse support added
-* Raygun4JS also includes the unique user tracking feature
+* Raygun4JS also includes Customer Experience Monitoring
 * Restructured the settings screen
 * JavaScript error tagging option added
 * Fixed an issue where the Send Test Error page wouldn't display results
@@ -115,7 +115,7 @@ If you enable this feature the currently logged in user's email address, first n
 * Raygun Dashboard uses more space to provide a better user experience
 * Updated notifications
 * Raygun4JS tracks the version Wordpress being used
-* Unique user tracking also tracks the users first & last names
+* Customer Experience Monitoring also tracks the users first & last names
 
 = 1.7.3 =
 
@@ -174,7 +174,7 @@ If you enable this feature the currently logged in user's email address, first n
 
 = 1.1.0.0 =
 
-* Added Unique User tracking support to Settings page
+* Added Customer Experience Monitoring support to Settings page
 * Updated internal Raygun4PHP to use latest v1.1
 
 = 1.0.3.0 =

--- a/settings.php
+++ b/settings.php
@@ -27,11 +27,11 @@
 
         <tr>
           <th>
-            <label for="rg4wp_usertracking"><?php _e("Customer Experience Monitoring"); ?></label>
+            <label for="rg4wp_usertracking"><?php _e("Customers"); ?></label>
           </th>
           <td>
             <fieldset>
-              <legend class="screen-reader-text"><span>Customer Experience Monitoring</span></legend>
+              <legend class="screen-reader-text"><span>Customers</span></legend>
               <label for="rg4wp_usertracking">
                 <input type="checkbox" name="rg4wp_usertracking" id="rg4wp_usertracking"<?php echo get_option('rg4wp_usertracking') ? ' checked="checked"': '';?> value="1" />
                 <?php _e("Track user information"); ?>

--- a/settings.php
+++ b/settings.php
@@ -27,11 +27,11 @@
 
         <tr>
           <th>
-            <label for="rg4wp_usertracking"><?php _e("User Tracking"); ?></label>
+            <label for="rg4wp_usertracking"><?php _e("Customer Experience Monitoring"); ?></label>
           </th>
           <td>
             <fieldset>
-              <legend class="screen-reader-text"><span>User tracking</span></legend>
+              <legend class="screen-reader-text"><span>Customer Experience Monitoring</span></legend>
               <label for="rg4wp_usertracking">
                 <input type="checkbox" name="rg4wp_usertracking" id="rg4wp_usertracking"<?php echo get_option('rg4wp_usertracking') ? ' checked="checked"': '';?> value="1" />
                 <?php _e("Track user information"); ?>


### PR DESCRIPTION
## [SS-607:](https://raygun.atlassian.net/browse/SS-607) Replace references to 'User tracking' with 'Customers'

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' needs to be discussed and planned for.**

### Description 📝 
This PR is to replace references from 'User tracking' to 'Customers' within the Wordpress Raygun provider

**Updates**
👉 Replace references within the settings page
👉 Replace references within README.md file

### Test plan 🧪 
- Make sure 'Users' is a term no longer associated with Customers/Customer Experience Monitoring

### Browser compatibility 🖥️
- [ ] Tested in latest Firefox
- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Works in IE 11

### Author to check 👓 
- [ ] Builds pass
- [ ] Run E2E tests manually
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written

### Reviewer to check ✔️ 
- [ ] Change has been tested on Beta
- [ ] Code is written to standards
- [ ] Appropriate tests have been written

[Engineering docs](https://raygunners.quip.com/ah5PA7OHZaUk)
