### PR TITLE
Add ignore third-party errors option

### DIFF
--- a/main.php
+++ b/main.php
@@ -47,6 +47,10 @@ function rg4wp_js() {
         $script .= 'rg4js("enableCrashReporting", true);' . "\n";
     }
 
+    if (1 == get_option('rg4wp_js_ignore3rdpartyerrors')) {      
+        $script .= 'rg4js("options", { ignore3rdPartyErrors: true });' . "\n";
+    }
+
     if (get_option('rg4wp_js_tags')) {
         $script .= 'rg4js("withTags",[';
         $tags = explode(',', get_option('rg4wp_js_tags'));
@@ -212,6 +216,7 @@ function rg4wp_register_settings() {
     register_setting('rg4wp', 'rg4wp_status');
     register_setting('rg4wp', 'rg4wp_404s');
     register_setting('rg4wp', 'rg4wp_js');
+    register_setting('rg4wp', 'rg4wp_js_ignore3rdpartyerrors');
     register_setting('rg4wp', 'rg4wp_usertracking');
     register_setting('rg4wp', 'rg4wp_ignoredomains');
     register_setting('rg4wp', 'rg4wp_pulse');
@@ -227,6 +232,7 @@ function rg4wp_install() {
     add_option('rg4wp_usertracking', '0');
     add_option('rg4wp_404s', '1');
     add_option('rg4wp_js', '1');
+    add_option('rg4wp_js_ignore3rdpartyerrors', '1');
     add_option('rg4wp_ignoredomains', '');
     add_option('rg4wp_pulse', '');
     add_option('rg4wp_js_tags', '');
@@ -240,6 +246,7 @@ function rg4wp_uninstall() {
     delete_option('rg4wp_status');
     delete_option('rg4wp_404s');
     delete_option('rg4wp_js');
+    delete_option('rg4wp_js_ignore3rdpartyerrors');
     delete_option('rg4wp_usertracking');
     delete_option('rg4wp_ignoredomains');
     delete_option('rg4wp_pulse');

--- a/main.php
+++ b/main.php
@@ -237,7 +237,7 @@ function rg4wp_install() {
     add_option('rg4wp_pulse', '');
     add_option('rg4wp_js_tags', '');
     add_option('rg4wp_async', '0');
-    add_option('rg4wp_noadmintracking', '0');
+    add_option('rg4wp_noadmintracking', '1');
 }
 
 function rg4wp_uninstall() {

--- a/settings.php
+++ b/settings.php
@@ -63,6 +63,13 @@
                                 <?php _e("Client-side errors"); ?> (JavaScript)
                             </label>
                             <br/>
+                            <label for="rg4wp_js_ignore3rdpartyerrors">
+                                <input type="checkbox" name="rg4wp_js_ignore3rdpartyerrors"
+                                       id="rg4wp_js_ignore3rdpartyerrors"<?php echo get_option('rg4wp_js_ignore3rdpartyerrors') ? ' checked="checked"' : ''; ?>
+                                       value="1"/>
+                                <?php _e("Ignore third-party errors"); ?>
+                            </label>
+                            <br/>
                             <br/>
                             <label for="rg4wp_noadmintracking">
                                 <input type="checkbox" name="rg4wp_noadmintracking"

--- a/settings.php
+++ b/settings.php
@@ -63,7 +63,7 @@
                                 <?php _e("Client-side errors"); ?> (JavaScript)
                             </label>
                             <br/>
-                            <label for="rg4wp_js_ignore3rdpartyerrors" style="margin-left: 20px;">
+                            <label for="rg4wp_js_ignore3rdpartyerrors" style="padding-left: 20px;">
                                 <input type="checkbox" name="rg4wp_js_ignore3rdpartyerrors"
                                        id="rg4wp_js_ignore3rdpartyerrors"<?php echo get_option('rg4wp_js_ignore3rdpartyerrors') ? ' checked="checked"' : ''; ?>
                                        value="1"/>

--- a/settings.php
+++ b/settings.php
@@ -63,7 +63,7 @@
                                 <?php _e("Client-side errors"); ?> (JavaScript)
                             </label>
                             <br/>
-                            <label for="rg4wp_js_ignore3rdpartyerrors">
+                            <label for="rg4wp_js_ignore3rdpartyerrors" style="margin-left: 20px;">
                                 <input type="checkbox" name="rg4wp_js_ignore3rdpartyerrors"
                                        id="rg4wp_js_ignore3rdpartyerrors"<?php echo get_option('rg4wp_js_ignore3rdpartyerrors') ? ' checked="checked"' : ''; ?>
                                        value="1"/>


### PR DESCRIPTION
- Add [ignore third-party errors](https://raygun.com/documentation/language-guides/javascript/ignore-3rd-party-errors/) option.
- Set the default value of "Disable tracking on admin pages" (`rg4wp_noadmintracking`) to true.

Both changes can help mitigate error spam.