### PR TITLE
[Customer support]: Bump wordpress versions

### DIFF
--- a/raygun4wp.php
+++ b/raygun4wp.php
@@ -3,8 +3,8 @@
 Plugin Name: Raygun
 Plugin URI: http://github.com/mindscapehq/raygun4wordpress
 Description: Exceptional error, performance, user tracking and more with Raygun.com. This service integrates Raygun Crash Reporting which lets you monitor your site's health with beautiful graphs and comprehensive reports, so you are always aware of any points of failure. With Raygun's Real User Monitoring you can monitor the performance of every individual user session, so you can discover and fix fundamental bottlenecks that affect your end user experience. This plugin has a simple one-minute, no-code-required installation.
-Version: 2.0.1.0
-Requires at least: 5.3
+Version: 2.1.0.0
+Requires at least: 6.5.4
 Requires PHP: 7.4
 Author: Raygun
 Author URI: http://raygun.com

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,9 @@ Finally, if you so desire, you should be able to visit the root network site, ac
 
 == Changelog  ==
 
+= 2.1.0.0 =
+* Add ignore third-party errors option
+
 = 2.0.1.0 =
 * Bump Raygun4PHP dependency to v2.3.1 to improve support for PHP version 8.2
 


### PR DESCRIPTION
This PR is to remove the yellow banner from our provider (to show that we have tested our plugin on the last 3 version of Wordpress) and also bump the version to support the previous PR merged 