### PR TITLE
Update stable release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ As of 2.0.0, asynchronous sending is avaliable on both Unix and Windows based sy
 
 As of 2.0.0, errors that fail to send to Raygun will be logged to the standard WordPress log file (`WP_CONTENT_DIR`**/debug.log**).
 
+## Ignore 3rd-party errors
+
+As of 2.1.0, you can now ignore 3rd-party errors from being sent to Raygun. You can enable this option via the plugin settings.
+
 ---------
 
 Changelog
 ---------
+- 2.1.1: Bump stable version
+- 2.1.0: Add ignore third-party errors option and bump required WordPress version
 - 2.0.1: Bump Raygun4PHP dependency to v2.3.1 to improve support for PHP version 8.2
 - 2.0.0: Switch to Composer for dependency management; Bump Raygun4PHP dependency to v2.3.0; Use new async sending guzzle (adds support for async on Windows); Switch Raygun4JS dependency to grab latest CDN distribution; Add error type tagging; Log errors that fail to send to Raygun; Add setting to disable tracking on admin pages; Rename Mindscape namespace to Raygun (src); Improve RaygunClientManager such that setting changes take effect immediately; Correct relationship between error handler and shutdown handler; Miscellaneous bug fixes, code improvements, UI and documentation updates
 - 1.9.3: Updated User Tracking to Customers.

--- a/raygun4wp.php
+++ b/raygun4wp.php
@@ -3,7 +3,7 @@
 Plugin Name: Raygun
 Plugin URI: http://github.com/mindscapehq/raygun4wordpress
 Description: Exceptional error, performance, user tracking and more with Raygun.com. This service integrates Raygun Crash Reporting which lets you monitor your site's health with beautiful graphs and comprehensive reports, so you are always aware of any points of failure. With Raygun's Real User Monitoring you can monitor the performance of every individual user session, so you can discover and fix fundamental bottlenecks that affect your end user experience. This plugin has a simple one-minute, no-code-required installation.
-Version: 2.1.0.0
+Version: 2.1.1.0
 Requires at least: 6.5.4
 Requires PHP: 7.4
 Author: Raygun

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,7 @@ Finally, if you so desire, you should be able to visit the root network site, ac
 
 == Changelog  ==
 
-= 2.1.1 =
+= 2.1.1.0 =
 * Bump stable version
 
 = 2.1.0.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: mindscapehq
 Tags: crash reporting, error monitoring, user experience monitoring, core web vitals, raygun, error reporting, error tracking, bug tracking, real user monitoring, exception, JavaScript, PHP
 Requires at least: 6.5.4
-Tested up to: 6.1.1
-Stable tag: 2.1.0.0
+Tested up to: 6.5.4
+Stable tag: 2.1.1.0
 Requires PHP: 7.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Raygun ===
 Contributors: mindscapehq
 Tags: crash reporting, error monitoring, user experience monitoring, core web vitals, raygun, error reporting, error tracking, bug tracking, real user monitoring, exception, JavaScript, PHP
-Requires at least: 5.3
+Requires at least: 6.5.4
 Tested up to: 6.1.1
-Stable tag: 2.0.1.0
+Stable tag: 2.1.0.0
 Requires PHP: 7.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -74,8 +74,11 @@ Finally, if you so desire, you should be able to visit the root network site, ac
 
 == Changelog  ==
 
+= 2.1.1 =
+* Bump stable version
+
 = 2.1.0.0 =
-* Add ignore third-party errors option
+* Add ignore third-party errors option and bump WordPress required version 
 
 = 2.0.1.0 =
 * Bump Raygun4PHP dependency to v2.3.1 to improve support for PHP version 8.2


### PR DESCRIPTION
I had missed adding the stable release which meant that the information for the next version was not available to view. 

Updates in this PR - 
- Bump stable version
- Add more docs 
- Bump plugin version as a whole